### PR TITLE
Turn the vcsrepo revision parameter into a variable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,11 @@ class { 'ghebackups':
     Defines the location of the backup-utils repository.
     Defaults to https://github.com/github/backup-utils.git.
 
+####`revision`
+    Defines the branch name or a commit SHA or tag of the backup-utils repo.
+    Defaults to master.
+
+
 
 ## Development
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -75,6 +75,7 @@ class ghebackups (
   $log_backup = $ghebackups::params::log_backup,
   $log_restore = $ghebackups::params::log_restore,
   $restore = $ghebackups::params::restore,
+  $revision = $ghebackups::params::revision,
   $user = $ghebackups::params::user,
   $cron_hour = $ghebackups::params::cron_hour,
   $ghe_hostname = $ghebackups::params::ghe_hostname,
@@ -94,6 +95,7 @@ class ghebackups (
   class {'ghebackups::install':
     install_location      => $ghebackups::install_location,
     ghe_backup_utils_repo => $ghebackups::ghe_backup_utils_repo,
+    revision              => $ghebackups::revision,
     user                  => $ghebackups::user
   } ->
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,6 +1,7 @@
 class ghebackups::install (
   $ghe_backup_utils_repo,
   $install_location,
+  $revision,
   $user,
 ) {
 
@@ -9,6 +10,6 @@ class ghebackups::install (
     user     => $user,
     provider => git,
     source   => $ghe_backup_utils_repo,
-    revision => 'master',
+    revision => $revision,
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,6 +12,7 @@ class ghebackups::params {
   $ghe_num_snapshots = 48
   $ghe_restore_host=''
   $ghe_extra_ssh_opts='-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no'
+  $revision = 'master'
   $user = 'root'
   $packages = [
     'git',


### PR DESCRIPTION
Some organizations may want to lock the backup-utils repo to a specific
version to avoid potential problems as the code continues to be
developed.

Thanks for providing this Puppet module! 