### PR TITLE
Provide ghe_create_data_dir parameter to ghebackups::config manifest.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -2,6 +2,7 @@ class ghebackups::config (
   $install_location,
   $user,
   $ghe_hostname,
+  $ghe_create_data_dir,
   $ghe_data_dir,
   $ghe_num_snapshots,
   $ghe_restore_host,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -79,6 +79,7 @@ class ghebackups (
   $user = $ghebackups::params::user,
   $cron_hour = $ghebackups::params::cron_hour,
   $ghe_hostname = $ghebackups::params::ghe_hostname,
+  $ghe_create_data_dir = $ghebackups::params::ghe_create_data_dir,
   $ghe_data_dir = $ghebackups::params::ghe_data_dir,
   $ghe_num_snapshots = $ghebackups::params::ghe_num_snapshots,
   $ghe_restore_host = $ghebackups::params::ghe_restore_host,
@@ -100,13 +101,14 @@ class ghebackups (
   } ->
 
   class {'ghebackups::config':
-    install_location   => $ghebackups::install_location,
-    user               => $ghebackups::user,
-    ghe_hostname       => $ghebackups::ghe_hostname,
-    ghe_data_dir       => $ghebackups::ghe_data_dir,
-    ghe_num_snapshots  => $ghebackups::ghe_num_snapshots,
-    ghe_restore_host   => $ghebackups::ghe_restore_host,
-    ghe_extra_ssh_opts => $ghebackups::ghe_extra_ssh_opts,
+    install_location    => $ghebackups::install_location,
+    user                => $ghebackups::user,
+    ghe_hostname        => $ghebackups::ghe_hostname,
+    ghe_create_data_dir => $ghebackups::ghe_create_data_dir,
+    ghe_data_dir        => $ghebackups::ghe_data_dir,
+    ghe_num_snapshots   => $ghebackups::ghe_num_snapshots,
+    ghe_restore_host    => $ghebackups::ghe_restore_host,
+    ghe_extra_ssh_opts  => $ghebackups::ghe_extra_ssh_opts,
   } ->
 
   class {'ghebackups::cron':


### PR DESCRIPTION
The ghe_create_data_dir parameter is the only one not provided to the
ghebackups::config class declaration in the init.pp.

With future parser off, all values, including ghe_create_data_dir are
set properly in the template config file.

With future parser enabled, the default value 'yes' for
ghe_create_data_dir is not parsed. This results in an empty string in
the config file that ends up on the node.

If you try to specify a value in the ghebackups declaration, you end up
getting the following error.

Error: Invalid parameter ghe_create_data_dir on Class[Ghebackups]

Looks like the right thing to do is specify the ghe_create_data_dir
parameter the same way the other template parameters are done.